### PR TITLE
Code that manages applied control schemes

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -7,6 +7,7 @@ package frc.robot;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.robot.controls.Controls;
 
 /**
  * The VM is configured to automatically run this class, and to call the
@@ -101,7 +102,7 @@ public class Robot extends TimedRobot {
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }
-    m_robotContainer.m_driveTrain.zeroHeading();
+    Controls.m_driveTrain.zeroHeading();
   }
 
   /** This function is called periodically during operator control. */

--- a/src/main/java/frc/robot/commands/DriveCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCommand.java
@@ -26,7 +26,16 @@ public class DriveCommand extends Command {
     this.m_linearYSupplier = m_linearYSupplier;
     this.m_angularSpeedSupplier = m_angularSpeedSupplier;
     this.m_linearBoostSupplier = m_linearBoostSupplier;
+    this.addRequirements(m_driveSubsystem);
+  }
 
+  public DriveCommand(DriveSubsystem subsystem, DoubleSupplier m_linearXSupplier, DoubleSupplier m_linearYSupplier,
+      DoubleSupplier m_angularSpeedSupplier, DoubleSupplier m_linearBoostSupplier) {
+    this.m_driveSubsystem = subsystem;
+    this.m_linearXSupplier = m_linearXSupplier;
+    this.m_linearYSupplier = m_linearYSupplier;
+    this.m_angularSpeedSupplier = m_angularSpeedSupplier;
+    this.m_linearBoostSupplier = () -> m_linearBoostSupplier.getAsDouble() >= 0.5;
     this.addRequirements(m_driveSubsystem);
   }
 

--- a/src/main/java/frc/robot/controls/ControlSchemeManager.java
+++ b/src/main/java/frc/robot/controls/ControlSchemeManager.java
@@ -1,0 +1,513 @@
+package frc.robot.controls;
+
+import java.util.ArrayList;
+
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import frc.robot.controls.Input.InputDevice;
+import frc.robot.controls.Input.InputMap;
+import frc.utils.SenderNT;
+
+/**
+ * ControlSchemeManager manages an array of control schemes and automatically
+ * assigns input-action bindings depending on the inputs that are available
+ */
+public class ControlSchemeManager implements Sendable {
+
+	/**
+	 * ControlSchemeBase defines the requirements for a compatible control scheme
+	 */
+	public static interface ControlSchemeBase {
+		public static interface Compat_F {
+			public InputDevice[] test(InputDevice... inputs);
+		}
+
+		public static interface Setup_F {
+			public void run(InputDevice... inputs);
+		}
+
+		/**
+		 * Determines if the inputs currently connected to the DS are sufficient to
+		 * initialize the control scheme
+		 * 
+		 * @param inputs an array of available inputs - usually of length
+		 *               DriverStation.kJoystickPorts
+		 * @return an array of inputs that should be passed to setup() to initialize the
+		 *         control scheme, or null if the requirements are not met
+		 */
+		public InputDevice[] compatible(InputDevice... inputs);
+
+		/**
+		 * Initializes the control scheme.
+		 * 
+		 * @param inputs The input array as returned directly from compatible(). The
+		 *               order of inputs in that array is the same as in this array
+		 */
+		public void setup(InputDevice... inputs);
+
+		/** Optional callback for debinding the scheduled bindings */
+		default public void shutdown() {
+		}
+
+		/**
+		 * What name should the selector use to identify this control scheme
+		 * 
+		 * @return The name or description of the control scheme
+		 */
+		public String getDesc();
+	}
+
+	public static class ControlScheme implements ControlSchemeBase {
+		private final Compat_F compatibility;
+		private final Setup_F setup;
+		private final Runnable shutdown;
+		private final String desc;
+
+		/**
+		 * @param description Description of the control scheme.
+		 * @param compat      Compatibility function.
+		 * @param setup       Setup function.
+		 */
+		public ControlScheme(String description, Compat_F compat, Setup_F setup) {
+			this(description, compat, setup, null);
+		}
+
+		/**
+		 * @param description Description of the control scheme.
+		 * @param compat      Compatibility function.
+		 * @param setup       Setup function.
+		 * @param shutdown    Shutdown function.
+		 */
+		public ControlScheme(String description, Compat_F compat, Setup_F setup, Runnable shutdown) {
+			this.compatibility = compat;
+			this.setup = setup;
+			this.shutdown = shutdown;
+			;
+			this.desc = description;
+		}
+
+		@Override
+		public String getDesc() {
+			return this.desc;
+		}
+
+		@Override
+		public InputDevice[] compatible(InputDevice... inputs) {
+			return this.compatibility.test(inputs);
+		}
+
+		@Override
+		public void setup(InputDevice... inputs) {
+			this.setup.run(inputs);
+		}
+
+		@Override
+		public void shutdown() {
+			if (this.shutdown != null) {
+				this.shutdown.run();
+			}
+		}
+
+	}
+
+	/**
+	 * the AutomatedTester class is designed for automated testing of control
+	 * schemes. It takes input requirements and matches them with available input
+	 * devices. If all requirements are met, it returns an array of matched
+	 * InputDevice objects; otherwise, it returns null.
+	 */
+	public static class AutomatedTester implements ControlSchemeBase.Compat_F {
+		private final InputMap[] requirements;
+		private final InputDevice[] buff; // The array [reference] is final, but the assignments are not.
+
+		/**
+		 * Constructor for AutomatedTester.
+		 *
+		 * @param requirements InputMap requirements.
+		 */
+		public AutomatedTester(InputMap... requirements) {
+			this.requirements = requirements;
+			this.buff = new InputDevice[requirements.length];
+		}
+
+		/**
+		 * This method is essentially a big matching function.
+		 *
+		 * @param inputs Input devices to test.
+		 * @return An array of matched InputDevices or null if not all requirements are
+		 *         met.
+		 */
+		@Override
+		public InputDevice[] test(InputDevice... inputs) {
+			int[] avail, requirements = new int[this.requirements.length]; // Look-up tables for inputs (param) and
+			// this.requirements, respectively
+			int found = 0;
+
+			if (inputs.length == DriverStation.kJoystickPorts) {
+				avail = new int[] { 0, 1, 2, 3, 4, 5 }; // Available ports: 0 through (DriverStation.kJoystickPorts - 1)
+			} else {
+				avail = new int[inputs.length];
+				for (int i = 0; i < avail.length; i++) {
+					avail[i] = inputs[i].getPort();
+				}
+			}
+
+			for (int i = 0; i < requirements.length; i++) {
+				requirements[i] = i;
+			}
+
+			for (int i = found; i < avail.length; i++) { // For each remaining port:
+				int p = avail[i];
+				for (int r = found; r < requirements.length; r++) { // For each remaining requirement:
+					if (this.requirements[requirements[r]].compatible(p)) { // If compatible:
+						this.buff[requirements[r]] = inputs[p];
+						if (i != found) {
+							for (int q = i; q > found; q--) { // Start at i, work backwards until @ found
+								avail[q] = avail[q - 1]; // Bump all values before i up an index
+							}
+						}
+						if (r != found) {
+							for (int q = r; q > found; q--) { // Same as above but for the requirements look-up table
+								requirements[q] = requirements[q - 1];
+							}
+						}
+						found++;
+						break;
+					}
+				}
+				if (found == this.requirements.length) {
+					return this.buff;
+				}
+			}
+			return null;
+		}
+	}
+
+	/**
+	 * Enum representing different preferences for handling ambiguous control scheme
+	 * solutions.
+	 */
+	public static enum AmbiguousSolution {
+		NONE,
+		PREFER_COMPLEX,
+		PREFER_SIMPLE
+	}
+
+	private final ArrayList<ControlSchemeBase> schemes = new ArrayList<>();
+	private final InputDevice[] inputs = new InputDevice[DriverStation.kJoystickPorts]; // make static?
+	private SendableChooser<Integer> options = new SendableChooser<>();
+	private String applied = "None";
+	private AmbiguousSolution ambiguousPreference = AmbiguousSolution.PREFER_COMPLEX;
+
+	/**
+	 * Initializes options and input devices.
+	 */
+	public ControlSchemeManager() {
+		this.options.setDefaultOption("Automatic", Integer.valueOf(-1));
+		for (int i = 0; i < this.inputs.length; i++) {
+			this.inputs[i] = new InputDevice(i);
+		}
+	}
+
+	@Override
+	public void initSendable(SendableBuilder b) {
+		b.addStringProperty("Applied Control Scheme", () -> this.applied, null);
+	}
+
+	/**
+	 * Add a new control scheme to the manager.
+	 * 
+	 * @param CSBase ControlSchemeBase to be added.
+	 */
+	public void addScheme(ControlSchemeBase CSBase) {
+		this.options.addOption(CSBase.getDesc(), Integer.valueOf(this.schemes.size()));
+		this.schemes.add(CSBase);
+	}
+
+	/**
+	 * Overloaded method to add a new control scheme with compatibility and setup
+	 * functions.
+	 * 
+	 * @param description Description of the control scheme.
+	 * @param compat      Compatibility function.
+	 * @param setup       Setup function.
+	 */
+	public void addScheme(String description, ControlSchemeBase.Compat_F compat, ControlSchemeBase.Setup_F setup) {
+		this.options.addOption(description, Integer.valueOf(this.schemes.size()));
+		this.schemes.add(new ControlScheme(description, compat, setup));
+	}
+
+	/**
+	 * Overloaded method to add a new control scheme with compatibility, setup, and
+	 * shutdown functions.
+	 * 
+	 * @param description Description of the control scheme.
+	 * @param compat      Compatibility function.
+	 * @param setup       Setup function.
+	 * @param shutdown    Shutdown function.
+	 */
+	public void addScheme(String description, ControlSchemeBase.Compat_F compat, ControlSchemeBase.Setup_F setup,
+			Runnable shutdown) {
+		this.options.addOption(description, Integer.valueOf(this.schemes.size()));
+		this.schemes.add(new ControlScheme(description, compat, setup, shutdown));
+	}
+
+	/**
+	 * Overloaded method to add a new control scheme with compatibility, setup, and
+	 * shutdown functions.
+	 * 
+	 * @param description  Description of the control scheme.
+	 * @param setup        Setup function.
+	 * @param requirements InputMap requirements.
+	 */
+	public void addScheme(String description, ControlSchemeBase.Setup_F setup, InputMap... requirements) {
+		this.addScheme(description, new AutomatedTester(requirements), setup);
+	}
+
+	/**
+	 * Overloaded method to add a new control scheme with compatibility, setup, and
+	 * shutdown functions.
+	 * 
+	 * @param description  Description of the control scheme.
+	 * @param setup        Setup function.
+	 * @param shutdown     Shutdown function.
+	 * @param requirements InputMap requirements.
+	 */
+	public void addScheme(String description, ControlSchemeBase.Setup_F setup, Runnable shutdown,
+			InputMap... requirements) {
+		this.addScheme(description, new AutomatedTester(requirements), setup, shutdown);
+	}
+
+	/**
+	 * Set the default control scheme.
+	 * 
+	 * @param CSBase ControlSchemeBase to be set as default.
+	 */
+	public void setDefault(ControlSchemeBase CSBase) {
+		this.options.setDefaultOption(CSBase.getDesc(), Integer.valueOf(this.schemes.size()));
+		this.schemes.add(CSBase);
+	}
+
+	/**
+	 * Overloaded method to set the default control scheme by creating a new scheme.
+	 * 
+	 * @param description Description of the control scheme.
+	 * @param compat      Compatibility function.
+	 * @param setup       Setup function.
+	 */
+	public void setDefault(String description, ControlSchemeBase.Compat_F compat, ControlSchemeBase.Setup_F setup) {
+		this.options.setDefaultOption(description, Integer.valueOf(this.schemes.size()));
+		this.schemes.add(new ControlScheme(description, compat, setup));
+	}
+
+	/**
+	 * Overloaded method to set the default control scheme by creating a new scheme.
+	 * 
+	 * @param description Description of the control scheme.
+	 * @param compat      Compatibility function.
+	 * @param setup       Setup function.
+	 * @param shutdown    Shutdown function.
+	 */
+	public void setDefault(String description, ControlSchemeBase.Compat_F compat, ControlSchemeBase.Setup_F setup,
+			Runnable shutdown) {
+		this.options.setDefaultOption(description, Integer.valueOf(this.schemes.size()));
+		this.schemes.add(new ControlScheme(description, compat, setup, shutdown));
+	}
+
+	/**
+	 * Overloaded method to set the default control scheme by creating a new
+	 * AutomatedTester.
+	 * 
+	 * @param description  Description of the control scheme.
+	 * @param setup        Setup function.
+	 * @param requirements InputMap requirements.
+	 */
+	public void setDefault(String description, ControlSchemeBase.Setup_F setup, InputMap... requirements) {
+		this.setDefault(description, new AutomatedTester(requirements), setup);
+	}
+
+	/**
+	 * Overloaded method to set the default control scheme by creating a new
+	 * AutomatedTester.
+	 * 
+	 * @param description  Description of the control scheme.
+	 * @param setup        Setup function.
+	 * @param shutdown     Shutdown function.
+	 * @param requirements InputMap requirements.
+	 */
+	public void setDefault(String description, ControlSchemeBase.Setup_F setup, Runnable shutdown,
+			InputMap... requirements) {
+		this.setDefault(description, new AutomatedTester(requirements), setup, shutdown);
+	}
+
+	/**
+	 * Publish the control scheme selector to SmartDashboard.
+	 */
+	public void publishSelector() {
+		this.publishSelector("Control Scheme");
+	}
+
+	/**
+	 * Overloaded method to publish the control scheme selector to SmartDashboard.
+	 * 
+	 * @param name Name of the control scheme selector.
+	 */
+	public void publishSelector(String name) {
+		SmartDashboard.putData(name + "/Selector", this.options);
+		SmartDashboard.putData(name, this);
+	}
+
+	/**
+	 * Overloaded method to publish the control scheme selector to SmartDashboard.
+	 * 
+	 * @param nt Specific Network table to publish to.
+	 */
+	public void publishSelector(SenderNT nt) {
+		this.publishSelector(nt, "Control Scheme");
+	}
+
+	/**
+	 * Overloaded method to publish the control scheme selector to SmartDashboard.
+	 * 
+	 * @param nt   Specific Network table to publish to.
+	 * @param name Name of the control scheme selector.
+	 */
+	public void publishSelector(SenderNT nt, String name) {
+		nt.putData(name + "/Selector", this.options);
+		nt.putData(name, this);
+	}
+
+	/**
+	 * Set the preference for handling ambiguous control scheme solutions.
+	 * 
+	 * @param preference AmbiguousSolution preference.
+	 */
+	public void setAmbiguousSolution(AmbiguousSolution preference) {
+		this.ambiguousPreference = preference;
+	}
+
+	/**
+	 * Clear the selection by resetting options and clearing schemes.
+	 */
+	synchronized public void clearSelection() {
+		this.options = new SendableChooser<>();
+		this.options.setDefaultOption("Automatic", Integer.valueOf(-1));
+		this.schemes.clear();
+	}
+
+	/**
+	 * Schedules a new Continuous Worker to select the most compatible control
+	 * scheme
+	 */
+	public synchronized void loopScheme() {
+		ContinuousSelectionBuffer buff = new ContinuousSelectionBuffer();
+		scheduleContinuousWorker(buff);
+	}
+
+	/**
+	 * Class representing a buffer for storing selected control schemes.
+	 */
+	private class SelectionBuffer {
+		public InputDevice[] devices = null, buff = null;
+	}
+
+	/**
+	 * Class representing a continuous selection buffer with additional tracking
+	 * information.
+	 */
+	private class ContinuousSelectionBuffer extends SelectionBuffer {
+		int prev_selected = -1, prev_active_id = -1;
+		boolean has_any = false;
+	}
+
+	private static int lastSelectedCompat = -2;
+	private static int lastSelectedId = -2;
+
+	/**
+	 * This method schedules the continuous worker responsible for selecting and
+	 * configuring control schemes. It checks compatibility, prioritizes schemes
+	 * based on complexity or simplicity, and handles ambiguous cases. The selected
+	 * scheme is set up for use.
+	 * 
+	 * @param sel ContinuousSelectionBuffer for additional tracking information.
+	 */
+	private void scheduleContinuousWorker(ContinuousSelectionBuffer sel) {
+		int id = this.options.getSelected();
+
+		// Check if there are no previous selections or if the current selection has
+		// changed
+		if (!sel.has_any || (sel.prev_selected != id && sel.prev_active_id != id)) {
+			if (id < 0) {
+				sel.devices = sel.buff = null;
+				int compat = -1;
+
+				// Iterate through available schemes
+				for (int i = 0; i < this.schemes.size(); i++) {
+					sel.buff = this.schemes.get(i).compatible(this.inputs);
+
+					// If a compatible scheme is found
+					if (sel.buff != null && sel.buff.length > 0) {
+						switch (this.ambiguousPreference) {
+							case PREFER_COMPLEX:
+								if (sel.devices == null || sel.buff.length > sel.devices.length) {
+									sel.devices = sel.buff;
+									compat = i;
+								}
+								break;
+							case PREFER_SIMPLE:
+								if (sel.devices == null || sel.buff.length < sel.devices.length) {
+									sel.devices = sel.buff;
+									compat = i;
+								}
+								break;
+							default:
+							case NONE:
+								compat = (compat == -1) ? i : -2;
+								sel.devices = sel.buff;
+						}
+					}
+				}
+
+				// If a compatible scheme was found
+				if (compat >= 0) {
+					if (sel.has_any) {
+						// Shut down the previously active scheme
+						this.schemes.get(sel.prev_active_id).shutdown();
+					}
+					// Set up the newly compatible scheme
+					if (compat != lastSelectedCompat) {
+						this.schemes.get(compat).setup(sel.devices);
+						this.applied = this.schemes.get(compat).getDesc();
+						sel.prev_active_id = compat;
+						sel.prev_selected = id;
+						sel.has_any = true;
+					}
+					lastSelectedCompat = compat;
+				} else if (compat < -1 && !sel.has_any) {
+					System.out.println("ControlSchemeManager: Ambiguous case detected, please refine selection.");
+				}
+			} else {
+				// If a specific scheme is selected
+				sel.devices = this.schemes.get(id).compatible(this.inputs);
+				if (sel.devices != null && sel.devices.length > 0) {
+					if (sel.has_any) {
+						// Shut down the previously active scheme
+						this.schemes.get(sel.prev_active_id).shutdown();
+					}
+					// Set up the selected scheme
+					if (id != lastSelectedId) {
+						this.schemes.get(id).setup(sel.devices);
+						this.applied = this.schemes.get(id).getDesc();
+						sel.prev_active_id = id;
+						sel.prev_selected = id;
+						sel.has_any = true;
+					}
+					lastSelectedId = id;
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/frc/robot/controls/Controls.java
+++ b/src/main/java/frc/robot/controls/Controls.java
@@ -1,0 +1,409 @@
+package frc.robot.controls;
+
+import java.util.ArrayList;
+
+import com.pathplanner.lib.commands.PathPlannerAuto;
+
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.PrintCommand;
+import frc.robot.controls.Input.ButtonBox;
+import frc.robot.Constants.OIConstants;
+import frc.robot.commands.AutoGoCommand;
+import frc.robot.commands.ClimbCommand;
+import frc.robot.commands.DriveCommand;
+import frc.robot.commands.FlingCommand;
+import frc.robot.commands.HookReleaseCommand;
+import frc.robot.commands.IntakeCommand;
+import frc.robot.commands.ManualFlingCommand;
+import frc.robot.commands.ManualIntakeCommand;
+import frc.robot.commands.ZeroHeadingCommand;
+import frc.robot.Robot;
+import frc.robot.RobotContainer;
+import frc.robot.controls.ControlSchemeManager.AmbiguousSolution;
+import frc.robot.controls.ControlSchemeManager.AutomatedTester;
+import frc.robot.controls.ControlSchemeManager.ControlScheme;
+import frc.robot.controls.ControlSchemeManager.ControlSchemeBase;
+import frc.robot.controls.Input.Attack3;
+import frc.robot.controls.Input.InputDevice;
+import frc.robot.controls.Input.InputMap;
+import frc.robot.controls.Input.PlayStation;
+import frc.robot.controls.Input.Xbox;
+import frc.robot.subsystems.ClimberSubsystem;
+import frc.robot.subsystems.DriveSubsystem;
+import frc.robot.subsystems.FloorIntake;
+import frc.utils.TriggerRunnable;
+import frc.robot.subsystems.Flinger;
+
+public final class Controls {
+	public static final Flinger m_flinger = new Flinger();
+	public static final FloorIntake m_intake = new FloorIntake();
+	public static final DriveSubsystem m_driveTrain = new DriveSubsystem();
+	public static final ClimberSubsystem m_climber = new ClimberSubsystem(); 
+
+	// Can be used to create situations where a specific list of schemes are used
+	// rather than all of them
+	public static enum FeatureLevel {
+		ALLSCHEMES
+	}
+
+	// Types of drives this robot can use, only really applicable to non-swerve
+	// robots that have the choice of either arcade or tank (not this robot)
+	public static enum DriveMode {
+		DEFAULTSWERVE
+	}
+
+	// By default, uses all schemes in getAllSchemes
+	public static final FeatureLevel DEFAULT_FEATURE_LEVEL = FeatureLevel.ALLSCHEMES;
+
+	// By default, uses swerve for drive
+	public static final DriveMode DEFAULT_DRIVE_MODE = DriveMode.DEFAULTSWERVE;
+
+	// A list of TriggerRunnables, cleared in deScheduleCommands whenever a new
+	// schemed is used
+	// to prevent duplicate commands
+	// All TriggerRunnables are polled in pollCommands, allowing their conditions to
+	// be checked
+	// and their commands to be ran
+	private static ArrayList<TriggerRunnable> triggerList = new ArrayList<TriggerRunnable>();
+
+	/**
+	 * @param robot
+	 * @return A list of all schemes that the robot can use (new schemes must be
+	 *         added to this list)
+	 */
+	private static ControlScheme[] getAllSchemes(Robot robot) {
+		return new ControlScheme[] {
+				buildScheme("Single Xbox", (InputDevice... i) -> singleXbox(robot, DEFAULT_DRIVE_MODE, i), Xbox.Map),
+				buildScheme("Single PlayStation", (InputDevice... i) -> singlePlayStation(robot, DEFAULT_DRIVE_MODE, i),
+						PlayStation.Map),
+				buildScheme("Dual Xbox", (InputDevice... i) -> dualXbox(robot, DEFAULT_DRIVE_MODE, i), Xbox.Map,
+						Xbox.Map),
+				buildScheme("Simple Arcade", (InputDevice... i) -> arcadeBoardSimple(robot, DEFAULT_DRIVE_MODE, i),
+						Attack3.Map, Attack3.Map),
+				buildScheme("Full Arcade", (InputDevice... i) -> arcadeBoardFull(robot, DEFAULT_DRIVE_MODE, i),
+						Attack3.Map, Attack3.Map, ButtonBox.Map),
+				buildScheme("Competition Board",
+						(InputDevice... i) -> fullCompetitionBoard(robot, DEFAULT_DRIVE_MODE, i),
+						Attack3.Map, Attack3.Map, ButtonBox.Map, Xbox.Map)
+		};
+	}
+
+	// Example of a specific list of schemes to use, this list of schemes on has
+	// just the
+	// "Full Arcade" scheme in it
+
+	// private static ControlScheme[] getCompetitionSchemes(Robot robot) {
+	// ControlScheme defaultSwerve = buildScheme("Full Arcade",
+	// (InputDevice... i) -> arcadeBoardFull(robot, DEFAULT_DRIVE_MODE, i),
+	// Attack3.Map, Attack3.Map, ButtonBox.Map);
+	// return DEFAULT_DRIVE_MODE == DriveMode.DEFAULTSWERVE ? new ControlScheme[] {
+	// defaultSwerve }
+	// : new ControlScheme[] { null };
+	// }
+
+	public static ControlSchemeManager setupControls(Robot robot, ControlSchemeManager manager) {
+		return setupControls(robot, manager, null);
+	}
+
+	public static ControlSchemeManager setupControls(Robot robot, ControlSchemeManager manager, FeatureLevel features) {
+		if (manager == null) {
+			manager = new ControlSchemeManager();
+		}
+		if (features == null) {
+			features = DEFAULT_FEATURE_LEVEL;
+		}
+		switch (features) {
+			case ALLSCHEMES: {
+				ControlScheme[] schemes = getAllSchemes(robot);
+				for (ControlScheme sch : schemes) {
+					manager.addScheme(sch);
+				}
+				break;
+			}
+
+			// Example case for specific feature group, this feature level only uses schemes
+			// from getCompetitionSchemes
+
+			// case COMPETITION: {
+			// ControlScheme[] schemes = getCompetitionSchemes(robot);
+			// manager.setDefault(schemes[0]);
+			// for (int i = 1; i < schemes.length; i++) {
+			// manager.addScheme(schemes[i]);
+			// }
+			// break;
+			// }
+		}
+		manager.setAmbiguousSolution(AmbiguousSolution.PREFER_COMPLEX);
+		manager.publishSelector("Control Scheme");
+		return manager;
+	}
+
+	/**
+	 * @param name         The name of the new ControlScheme
+	 * @param setup
+	 * @param requirements InputMap requirements for the new ControlScheme
+	 * @return New ControlScheme with the parameters specified
+	 */
+	private static ControlScheme buildScheme(String name, ControlSchemeBase.Setup_F setup, InputMap... requirements) {
+		return new ControlScheme(name, new AutomatedTester(requirements), setup);
+	}
+
+	/**
+	 * Removes all default commands and clears the triggerList, used in beginning of
+	 * every control scheme to prevent duplication of triggers & commands
+	 */
+	private static void deScheduleCommands() {
+		m_driveTrain.removeDefaultCommand();
+		m_flinger.removeDefaultCommand();
+		m_intake.removeDefaultCommand();
+		triggerList.clear();
+	}
+
+	/**
+	 * Polls all TriggerRunnables within triggerList, if a TriggerRunnable's
+	 * condition is true, it runs it's command
+	 */
+	public static void pollCommands() {
+		for (TriggerRunnable triggerRunnable : triggerList) {
+			triggerRunnable.poll();
+		}
+	}
+
+	// SECTION - Control Schemes
+	// Uses a Single Xbox Controller
+	private static void singleXbox(Robot robot, DriveMode drivemode, InputDevice... inputs) {
+		deScheduleCommands();
+		InputDevice xboxController = inputs[0];
+		Command drive_control = new DriveCommand(m_driveTrain,
+				Xbox.Analog.RX.getDriveInputSupplier(xboxController, 0, 1.0, 1.0),
+				Xbox.Analog.RY.getDriveInputSupplier(xboxController, 0, 1.0, 1.0),
+				Xbox.Analog.LX.getDriveInputSupplier(xboxController, 0, 1.0, 1.0),
+				Xbox.Analog.LT.getDriveInputSupplier(xboxController, OIConstants.kTriggerDeadband, 1.0, 1.0));
+		m_driveTrain.setDefaultCommand(drive_control);
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Fling
+				() -> Xbox.Analog.RT.getValueOf(xboxController) >= OIConstants.kTriggerDeadband,
+				new FlingCommand(m_flinger, m_intake)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Intake
+				() -> Xbox.Digital.RB.getValueOf(xboxController),
+				new IntakeCommand(m_flinger, m_intake)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Zero Heading
+				() -> Xbox.Digital.B.getValueOf(xboxController),
+				new ZeroHeadingCommand(m_driveTrain)));
+	}
+
+	// Uses a Single PlayStation controller
+	private static void singlePlayStation(Robot robot, DriveMode drivemode, InputDevice... inputs) {
+		deScheduleCommands();
+		InputDevice playstationController = inputs[0];
+		Command drive_control = new DriveCommand(m_driveTrain,
+				PlayStation.Analog.RX.getDriveInputSupplier(playstationController, 0, 1.0, 1.0),
+				PlayStation.Analog.RY.getDriveInputSupplier(playstationController, 0, 1.0, 1.0),
+				PlayStation.Analog.LX.getDriveInputSupplier(playstationController, 0, 1.0, 1.0),
+				PlayStation.Analog.LT.getDriveInputSupplier(playstationController, 0, 1.0, 1.0));
+		m_driveTrain.setDefaultCommand(drive_control);
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Fling
+				() -> PlayStation.Analog.RT.getValueOf(playstationController) >= OIConstants.kTriggerDeadband,
+				new FlingCommand(m_flinger, m_intake)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Intake
+				() -> PlayStation.Digital.RB.getValueOf(playstationController),
+				new IntakeCommand(m_flinger, m_intake)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Zero Heading
+				() -> PlayStation.Digital.O.getValueOf(playstationController),
+				new ZeroHeadingCommand(m_driveTrain)));
+	}
+
+	// Uses two Xbox controllers
+	private static void dualXbox(Robot robot, DriveMode drivemode, InputDevice... inputs) {
+		deScheduleCommands();
+		InputDevice xboxController1 = inputs[0];
+		@SuppressWarnings("unused")
+		InputDevice xboxController2 = inputs[1]; // Not used
+		Command drive_control = new DriveCommand(m_driveTrain,
+				Xbox.Analog.RX.getDriveInputSupplier(xboxController1, 0, 1.0, 1.0),
+				Xbox.Analog.RY.getDriveInputSupplier(xboxController1, 0, 1.0, 1.0),
+				Xbox.Analog.LX.getDriveInputSupplier(xboxController1, 0, 1.0, 1.0),
+				Xbox.Analog.LT.getDriveInputSupplier(xboxController1, OIConstants.kTriggerDeadband, 1.0, 1.0));
+		m_driveTrain.setDefaultCommand(drive_control);
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Fling
+				() -> Xbox.Analog.RT.getValueOf(xboxController1) >= OIConstants.kTriggerDeadband,
+				new FlingCommand(m_flinger, m_intake)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Intake
+				() -> Xbox.Digital.RB.getValueOf(xboxController1),
+				new IntakeCommand(m_flinger, m_intake)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Zero Heading
+				() -> Xbox.Digital.B.getValueOf(xboxController1),
+				new ZeroHeadingCommand(m_driveTrain)));
+	}
+
+	// Uses two Attack Joysticks
+	private static void arcadeBoardSimple(Robot robot, DriveMode drivemode, InputDevice... inputs) {
+		deScheduleCommands();
+		InputDevice leftStick = inputs[0];
+		InputDevice rightStick = inputs[1];
+		Command drive_control = new DriveCommand(m_driveTrain,
+				Attack3.Analog.X.getDriveInputSupplier(rightStick, 0, 1.0, 1.0),
+				Attack3.Analog.Y.getDriveInputSupplier(rightStick, 0, 1.0, 1.0),
+				Attack3.Analog.X.getDriveInputSupplier(leftStick, 0, 1.0, 1.0),
+				Attack3.Digital.TRI.getSupplier(leftStick));
+		m_driveTrain.setDefaultCommand(drive_control);
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Fling
+				() -> Attack3.Digital.TRI.getValueOf(rightStick),
+				new FlingCommand(m_flinger, m_intake)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Intake
+				() -> Attack3.Digital.TB.getValueOf(rightStick),
+				new IntakeCommand(m_flinger, m_intake)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Zero Heading
+				() -> Attack3.Digital.B2.getValueOf(rightStick),
+				new ZeroHeadingCommand(m_driveTrain)));
+	}
+
+	// Uses two Attack Joysticks and the Button Box
+	private static void arcadeBoardFull(Robot robot, DriveMode drivemode, InputDevice... inputs) {
+		deScheduleCommands();
+		InputDevice leftStick = inputs[0];
+		InputDevice rightStick = inputs[1];
+		InputDevice buttonBox = inputs[2];
+		Command drive_control = new DriveCommand(m_driveTrain,
+				Attack3.Analog.X.getDriveInputSupplier(rightStick, 0, 1.0, 1.0),
+				Attack3.Analog.Y.getDriveInputSupplier(rightStick, 0, 1.0, 1.0),
+				Attack3.Analog.X.getDriveInputSupplier(leftStick, 0, 1.0, 1.0),
+				Attack3.Digital.TRI.getSupplier(leftStick));
+		m_driveTrain.setDefaultCommand(drive_control);
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue,   // Fling
+				() -> Attack3.Digital.TRI.getValueOf(rightStick),
+				new FlingCommand(m_flinger, m_intake)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue,   // Intake
+				() -> Attack3.Digital.TB.getValueOf(rightStick),
+				new IntakeCommand(m_flinger, m_intake)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Zero Heading
+				() -> Attack3.Digital.B2.getValueOf(rightStick),
+				new ZeroHeadingCommand(m_driveTrain)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.whileTrue, // Climb
+				() -> ButtonBox.Digital.B1.getValueOf(buttonBox),
+				new ClimbCommand(m_climber)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.whileTrue, // Hook Release
+				() -> ButtonBox.Digital.B2.getValueOf(buttonBox),
+				new HookReleaseCommand(m_climber)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.whileTrue, // Manual Reverse Intake
+				() -> ButtonBox.Digital.B3.getValueOf(buttonBox),
+				new ManualIntakeCommand(m_intake, true)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.whileTrue, // Manual Intake
+				() -> ButtonBox.Digital.B4.getValueOf(buttonBox),
+				new ManualIntakeCommand(m_intake, false)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.whileTrue, // Manual Reverse Fling
+				() -> ButtonBox.Digital.B5.getValueOf(buttonBox),
+				new ManualFlingCommand(m_flinger, true)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.whileTrue, // Manual Fling
+				() -> ButtonBox.Digital.B6.getValueOf(buttonBox),
+				new ManualFlingCommand(m_flinger, false)));
+		// triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Camera Toggle
+		// 		() -> ButtonBox.Digital.B7.getValueOf(buttonBox),
+		// 		new PrintCommand("camera switch (toggle)")));
+		// triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Climber Toggle
+		// 		() -> ButtonBox.Digital.B8.getValueOf(buttonBox),
+		// 		new PrintCommand("climber switch (toggle)")));
+	}
+
+	// Uses two Attack Joysticks, the Button Box, and an Xbox controller
+	private static void fullCompetitionBoard(Robot robot, DriveMode drivemode, InputDevice... inputs) {
+		deScheduleCommands();
+		InputDevice leftStick = inputs[0];
+		InputDevice rightStick = inputs[1];
+		InputDevice buttonBox = inputs[2];
+		InputDevice xboxController = inputs[3]; // Not used
+		Command drive_control = new DriveCommand(m_driveTrain,
+				Attack3.Analog.X.getDriveInputSupplier(rightStick, 0, 1.0, 1.0),
+				Attack3.Analog.Y.getDriveInputSupplier(rightStick, 0, 1.0, 1.0),
+				Attack3.Analog.X.getDriveInputSupplier(leftStick, 0, 1.0, 1.0),
+				Attack3.Digital.TRI.getSupplier(leftStick));
+		m_driveTrain.setDefaultCommand(drive_control);
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue,   // Fling
+				() -> Attack3.Digital.TRI.getValueOf(rightStick),
+				new FlingCommand(m_flinger, m_intake)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue,   // Intake
+				() -> Attack3.Digital.TB.getValueOf(rightStick),
+				new IntakeCommand(m_flinger, m_intake)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Zero Heading
+				() -> Attack3.Digital.B2.getValueOf(rightStick),
+				new ZeroHeadingCommand(m_driveTrain)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.whileTrue, // Climb
+				() -> ButtonBox.Digital.B1.getValueOf(buttonBox),
+				new ClimbCommand(m_climber)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.whileTrue, // Hook Release
+				() -> ButtonBox.Digital.B2.getValueOf(buttonBox),
+				new HookReleaseCommand(m_climber)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.whileTrue, // Manual Reverse Intake
+				() -> ButtonBox.Digital.B3.getValueOf(buttonBox),
+				new ManualIntakeCommand(m_intake, true)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.whileTrue, // Manual Intake
+				() -> ButtonBox.Digital.B4.getValueOf(buttonBox),
+				new ManualIntakeCommand(m_intake, false)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.whileTrue, // Manual Reverse Fling
+				() -> ButtonBox.Digital.B5.getValueOf(buttonBox),
+				new ManualFlingCommand(m_flinger, true)));
+		triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.whileTrue, // Manual Fling
+				() -> ButtonBox.Digital.B6.getValueOf(buttonBox),
+				new ManualFlingCommand(m_flinger, false)));
+		// triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Camera Toggle
+		// 		() -> ButtonBox.Digital.B7.getValueOf(buttonBox),
+		// 		new PrintCommand("camera switch (toggle)")));
+		// triggerList.add(new TriggerRunnable(TriggerRunnable.LoopType.onTrue, // Climber Toggle
+		// 		() -> ButtonBox.Digital.B8.getValueOf(buttonBox),
+		// 		new PrintCommand("climber switch (toggle)")));
+	}
+	// !SECTION
+
+	// TUTORIAL - How to write a new control scheme
+	// Use the following shell:
+
+	// private static void nameOfScheme(Robot robot, DriveMode drivemode,
+	// InputDevice... inputs)
+	// {
+	// deScheduleCommands();
+	// InputDevice nameOfDevice = inputs[port]; //Step 1
+	// Command drive_control = new DriveCommand(m_driveTrain, //Step 2
+	// inputDeviceType.Analog/Digital.button.getDriveInputSupplier(controller, 0,
+	// 1.0, 1.0),
+	// inputDeviceType.Analog/Digital.button.getDriveInputSupplier(controller, 0,
+	// 1.0, 1.0),
+	// inputDeviceType.Analog/Digital.button.getDriveInputSupplier(controller, 0,
+	// 1.0, 1.0),
+	// inputDeviceType.Analog/Digital.button.getSupplier(controller),
+	// inputDeviceType.Analog/Digital.button.getSupplier(controller));
+	// m_driveTrain.setDefaultCommand(drive_control);
+	// triggerList.add(new TriggerRunnable(LoopType, //Step 3
+	// buttonSupplier,
+	// command));
+	// }
+
+	// Step 1: For each type of InputDevice you want to use add a new InputDevice,
+	// name it according to the
+	// type of device, then set the port to the port you want
+
+	// Step 2: For the drive change the inputDeviceTypes and buttons to what you
+	// want
+	// based on your device type's input map in Input.java
+	// Then change controller to the type of controller you are getting the input
+	// from
+	// Repeat for each subsystem the uses a defaultCommand
+
+	// Step 3: For each individual command that is being run, add a copy of the
+	// triggerList.add code
+	// Replace the loopType with the type of loop you would like, most of the types
+	// from the WPILib
+	// trigger class are usable such as onTrue and whileFalse, the available types
+	// can be seen in
+	// TriggerRunnable.LoopType
+	// Replace buttonSupplier with the supplier you would like to use, to convert a
+	// value function into
+	// a supplier, use a lambda expression, for example: () ->
+	// Attack3.Digital.TRI.getValueOf(rightStick)
+	// this would turn the getValueOf function for the Attack 3 trigger into a
+	// supplier rather than just
+	// a value function
+	// Replace command wih the type of command you would like to run, wether it be a
+	// new command or
+	// one from the commands folder
+	// !TUTORIAL
+}

--- a/src/main/java/frc/robot/controls/Input.java
+++ b/src/main/java/frc/robot/controls/Input.java
@@ -1,0 +1,997 @@
+package frc.robot.controls;
+
+import java.util.function.BooleanSupplier;
+import java.util.function.DoubleSupplier;
+
+import edu.wpi.first.math.filter.SlewRateLimiter;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.GenericHID;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
+
+/**
+ * This class houses an advanced input framework that extends the general
+ * purpose WPILib input system.
+ */
+public class Input {
+
+	/**
+	 * Interface for supplying joystick values (doubles)
+	 */
+	public static interface AnalogSupplier extends DoubleSupplier {
+		double get();
+
+		@Override
+		default double getAsDouble() {
+			return get();
+		}
+	}
+
+	/**
+	 * Interface for supplying button presses (booleans)
+	 */
+	public static interface DigitalSupplier extends BooleanSupplier {
+		boolean get();
+
+		@Override
+		default boolean getAsBoolean() {
+			return get();
+		}
+	}
+
+	/**
+	 * AnalogSlewSupplier limits the rate of output change (between calls) to a
+	 * maximum of that given in units/sec
+	 */
+	public static class AnalogSlewSupplier implements AnalogSupplier {
+
+		private final SlewRateLimiter limit;
+		private final DoubleSupplier source;
+
+		public AnalogSlewSupplier(DoubleSupplier src) {
+			this(src, Double.MAX_VALUE);
+		} // kind of pointless?
+
+		public AnalogSlewSupplier(DoubleSupplier src, double rate) {
+			this.limit = new SlewRateLimiter(rate, -rate, src.getAsDouble());
+			this.source = src;
+		}
+
+		@Override
+		public double get() {
+			return this.limit.calculate(this.source.getAsDouble());
+		}
+
+	}
+
+	/**
+	 * AnalogDeadzone applies a deadzone to an analog supplier, returning 0.0 if the
+	 * input is within the deadzone (+/-)
+	 */
+	public static class AnalogDeadzone implements AnalogSupplier {
+
+		private final DoubleSupplier source;
+		private final double deadzone;
+
+		public AnalogDeadzone(DoubleSupplier src, double dz) {
+			this.source = src;
+			this.deadzone = dz;
+		}
+
+		@Override
+		public double get() {
+			double i = this.source.getAsDouble();
+			return Math.abs(i) > this.deadzone ? i : 0.0;
+		}
+
+	}
+
+	/**
+	 * AnalogScalar simply scales the input by a constant (multiplication)
+	 */
+	public static class AnalogScalar implements AnalogSupplier {
+
+		private final DoubleSupplier source;
+		private final double scale;
+
+		public AnalogScalar(DoubleSupplier src, double scl) {
+			this.source = src;
+			this.scale = scl;
+		}
+
+		@Override
+		public double get() {
+			return this.source.getAsDouble() * this.scale;
+		}
+
+	}
+
+	/**
+	 * AnalogExponential acts a passthrough for a base supplier, and returns each
+	 * input taken to the given power
+	 */
+	public static class AnalogExponential implements AnalogSupplier {
+
+		private final DoubleSupplier source;
+		private final double power;
+
+		public AnalogExponential(DoubleSupplier src, double pow) {
+			this.source = src;
+			this.power = pow;
+		}
+
+		@Override
+		public double get() {
+			double i = this.source.getAsDouble();
+			return Math.copySign(Math.pow(Math.abs(i), this.power), i);
+		}
+
+	}
+
+	/**
+	 * DriveInputSupplier allows for the application of a deadzone, rescale, and
+	 * exponential power transformation on an input supplier - useful for driving
+	 * contexts as the name suggests
+	 */
+	public static class DriveInputSupplier implements AnalogSupplier {
+
+		private final DoubleSupplier source;
+		private final double exp_pow;
+		private final double scale; // when the input range is -1 to 1 this acts as a 'maximum output' modifier
+		private final double deadband;
+
+		public DriveInputSupplier(DoubleSupplier src, double deadband, double scale, double exp) {
+			this.source = src;
+			this.exp_pow = exp;
+			this.scale = scale;
+			this.deadband = deadband;
+		}
+
+		public DriveInputSupplier(DoubleSupplier src, double deadband, double scale) {
+			this(src, deadband, scale, 1.0);
+		}
+
+		public DriveInputSupplier(DoubleSupplier src, double deadband) {
+			this(src, deadband, 1.0, 1.0);
+		}
+
+		public static double compute(double x, double d) {
+			return compute(x, d, 1.0, 1.0);
+		}
+
+		public static double compute(double x, double d, double m) {
+			return compute(x, d, m, 1.0);
+		}
+
+		public static double compute(double x, double d, double m, double p) {
+			double ax = Math.abs(x);
+			if (ax < d) {
+				return 0;
+			}
+			double dp = d;
+			if (p != 1.0) {
+				dp = Math.pow(d, p);
+				ax = Math.pow(x, p);
+			}
+			double n = dp / (1.0 - dp);
+			return Math.signum(x) * m * ((1.0 + n) * ax - n);
+		}
+
+		@Override
+		public double get() {
+			return compute(this.source.getAsDouble(), this.deadband, this.scale, this.exp_pow);
+		}
+
+	}
+
+	/**
+	 * InputDevice extends all {@link GenericHID} functionality, but adds some
+	 * advanced trigger and POVButton mapping features.
+	 * It is also required for all Analog and Digital enum interfaces defined below.
+	 */
+	public static class InputDevice extends GenericHID {
+
+		private PovButton[] buttons = null;
+
+		private boolean verifyInfo() {
+			if (super.isConnected()) {
+				int digital_count = super.getButtonCount() + (super.getPOVCount() * 4);
+				if (this.buttons == null || this.buttons.length != digital_count) {
+					this.buttons = new PovButton[digital_count];
+					return true;
+				}
+			} else if (!super.isConnected() && this.buttons != null) {
+				this.buttons = null;
+				return false;
+			}
+			return this.buttons != null;
+		}
+
+		public InputDevice(int p) {
+			super(p);
+			this.verifyInfo();
+		}
+
+		@Override
+		public boolean getRawButton(int button) {
+			int _bc = super.getButtonCount();
+			if ((button > _bc) && (button <= _bc + (super.getPOVCount() * 4))) {
+				button = button - _bc;
+				return (super.getPOV((button - 1) / 4) / 90.0 + 1) == button;
+			} else {
+				return super.getRawButton(button);
+			}
+		}
+
+		public PovButton getTrigger(int button) { // returns dummy if joystick not connected
+			if (this.verifyInfo()) {
+				if (this.buttons[button - 1] == null) {
+					this.buttons[button - 1] = new PovButton(this, button);
+				}
+				return this.buttons[button - 1];
+			}
+			return PovButton.dummy;
+		}
+
+		public Trigger connectionTrigger() {
+			return new Trigger(() -> {
+				return super.isConnected();
+			});
+		}
+	}
+
+	/**
+	 * PovButton remaps all ports on a joystick to additional button indices past
+	 * those normally used. Functionality and use is
+	 * the same as a normal joystick button.
+	 */
+	public static class PovButton extends Trigger implements DigitalSupplier {
+
+		public static class Supplier implements DigitalSupplier {
+			private final int port, button;
+			private final boolean use_pov;
+
+			public Supplier(int port, int button) {
+				this.port = port;
+				int _bc = DriverStation.getStickButtonCount(this.port), _pc = DriverStation.getStickPOVCount(this.port);
+				this.use_pov = ((button > _bc) && (button <= _bc + (_pc * 4)));
+				if (this.use_pov) {
+					this.button = button - _bc;
+				} else {
+					this.button = button;
+				}
+			}
+
+			@Override
+			public boolean get() {
+				if (this.use_pov) {
+					return (DriverStation.getStickPOV(this.port, (this.button - 1) / 4) / 90.0 + 1) == this.button;
+				} else {
+					return DriverStation.getStickButton(this.port, this.button);
+				}
+			}
+		}
+
+		public static final PovButton dummy = new PovButton();
+
+		private PovButton() {
+			super(() -> false);
+		}
+
+		public PovButton(GenericHID device, int button) {
+			this(device.getPort(), button);
+		}
+
+		public PovButton(int port, int button) {
+			super(new PovButton.Supplier(port, button));
+		}
+
+		@Override
+		public boolean get() {
+			return super.getAsBoolean();
+		}
+
+	}
+
+	/**
+	 * AnalogMap defines all functions available to Analog enums (defined below)
+	 */
+	public static interface AnalogMap {
+		int getPortValue();
+
+		int getTotal();
+
+		default boolean compatible(GenericHID i) {
+			return i.getAxisCount() == this.getTotal();
+		}
+
+		default boolean compatible(int p) {
+			return DriverStation.getStickAxisCount(p) == this.getTotal();
+		}
+
+		default double getValueOf(GenericHID i) {
+			if (this.compatible(i)) {
+				return i.getRawAxis(this.getPortValue());
+			}
+			return 0.0;
+		}
+
+		default double getValueOf(int p) {
+			if (this.compatible(p)) {
+				return DriverStation.getStickAxis(p, this.getPortValue());
+			}
+			return 0.0;
+		}
+
+		default AnalogSupplier getSupplier(InputDevice i) {
+			if (this.compatible(i)) {
+				return () -> i.getRawAxis(this.getPortValue());
+			}
+			return () -> 0.0;
+		}
+
+		default AnalogSupplier getSupplier(int p) {
+			if (this.compatible(p)) {
+				return () -> DriverStation.getStickAxis(p, this.getPortValue());
+			}
+			return () -> 0.0;
+		}
+
+		default AnalogSlewSupplier getLimitedSupplier(InputDevice i, double rate) {
+			if (this.compatible(i)) {
+				return new AnalogSlewSupplier(() -> i.getRawAxis(this.getPortValue()), rate);
+			}
+			return new AnalogSlewSupplier(() -> 0.0);
+		}
+
+		default AnalogSlewSupplier getLimitedSupplier(int p, double rate) {
+			if (this.compatible(p)) {
+				return new AnalogSlewSupplier(() -> DriverStation.getStickAxis(p, this.getPortValue()), rate);
+			}
+			return new AnalogSlewSupplier(() -> 0.0);
+		}
+
+		default AnalogExponential getExponentialSupplier(InputDevice i, double pow) {
+			if (this.compatible(i)) {
+				return new AnalogExponential(() -> i.getRawAxis(this.getPortValue()), pow);
+			}
+			return new AnalogExponential(() -> 0.0, 1.0);
+		}
+
+		default AnalogExponential getExponentialSupplier(int p, double pow) {
+			if (this.compatible(p)) {
+				return new AnalogExponential(() -> DriverStation.getStickAxis(p, this.getPortValue()), pow);
+			}
+			return new AnalogExponential(() -> 0.0, 1.0);
+		}
+
+		default AnalogSupplier getExponentialLimitedSupplier(InputDevice i, double rate, double pow) {
+			if (this.compatible(i)) {
+				return new AnalogSlewSupplier(new AnalogExponential(() -> i.getRawAxis(this.getPortValue()), pow),
+						rate);
+			}
+			return () -> 0.0;
+		}
+
+		default AnalogSupplier getExponentialLimitedSupplier(int p, double rate, double pow) {
+			if (this.compatible(p)) {
+				return new AnalogSlewSupplier(
+						new AnalogExponential(() -> DriverStation.getStickAxis(p, this.getPortValue()), pow), rate);
+			}
+			return () -> 0.0;
+		}
+
+		default AnalogSupplier getDriveInputSupplier(InputDevice i, double deadzone, double scale, double exp) {
+			if (this.compatible(i)) {
+				return new DriveInputSupplier(() -> i.getRawAxis(this.getPortValue()), deadzone, scale, exp);
+			}
+			return () -> 0.0;
+		}
+
+		default AnalogSupplier getDriveInputSupplier(int p, double deadzone, double scale, double exp) {
+			if (this.compatible(p)) {
+				return new DriveInputSupplier(() -> DriverStation.getStickAxis(p, this.getPortValue()), deadzone, scale,
+						exp);
+			}
+			return () -> 0.0;
+		}
+	}
+
+	/**
+	 * DigitalMap defines all functions available to Digital enums defined below.
+	 * Provides integration with PovButton when available.
+	 */
+	public static interface DigitalMap {
+
+		/**
+		 * Implemented in extended classes
+		 * 
+		 * @return Integer value of the port
+		 */
+		int getPortValue();
+
+		/**
+		 * Implemented in extended classes
+		 * 
+		 * @return Total number of port options
+		 */
+		int getTotal();
+
+		default boolean compatible(GenericHID i) {
+			return i.getButtonCount() + (i.getPOVCount() * 4) == this.getTotal();
+		}
+
+		default boolean compatible(int p) {
+			return DriverStation.getStickButtonCount(p) + (DriverStation.getStickPOVCount(p) * 4) == this.getTotal();
+		}
+
+		default boolean isPovBindOf(GenericHID i) {
+			if (this.compatible(i)) {
+				return this.getPortValue() > i.getButtonCount();
+			}
+			return false;
+		}
+
+		default boolean isPovBindOf(int p) {
+			if (this.compatible(p)) {
+				return this.getPortValue() > DriverStation.getStickPOVCount(p);
+			}
+			return false;
+		}
+
+		default int getPovBindOf(GenericHID i) {
+			if (this.compatible(i) && this.isPovBindOf(i)) {
+				return (this.getPortValue() - i.getButtonCount()) / 4;
+			}
+			return -1;
+		}
+
+		default int getPovBindOf(int p) {
+			if (this.compatible(p) && this.isPovBindOf(p)) {
+				return (this.getPortValue() - DriverStation.getStickButtonCount(p)) / 4;
+			}
+			return -1;
+		}
+
+		default PovButton getCallbackFrom(InputDevice i) {
+			if (this.compatible(i)) {
+				return i.getTrigger(this.getPortValue());
+			}
+			return PovButton.dummy;
+		}
+
+		default PovButton getCallbackFrom(GenericHID i) {
+			if (this.compatible(i)) {
+				return new PovButton(i, this.getPortValue());
+			}
+			return PovButton.dummy;
+		}
+
+		default PovButton getCallbackFrom(int p) {
+			if (this.compatible(p)) {
+				return new PovButton(p, this.getPortValue());
+			}
+			return PovButton.dummy;
+		}
+
+		default boolean getValueOf(GenericHID i) {
+			if (this.isPovBindOf(i)) {
+				return (i.getPOV((this.getPortValue() - i.getButtonCount() - 1) / 4) / 90.0 + 1) == this.getPortValue()
+						- i.getButtonCount();
+			} else if (this.compatible(i)) {
+				return i.getRawButton(this.getPortValue());
+			}
+			return false;
+		}
+
+		default boolean getValueOf(int p) {
+			if (this.isPovBindOf(p)) {
+				return (DriverStation.getStickPOV(p,
+						(this.getPortValue() - DriverStation.getStickButtonCount(p) - 1) / 4)
+						/ 90.0 + 1) == this.getPortValue() - DriverStation.getStickButtonCount(p);
+			} else if (this.compatible(p)) {
+				return DriverStation.getStickButton(p, this.getPortValue());
+			}
+			return false;
+		}
+
+		default boolean getPressedValueOf(GenericHID i) {
+			if (this.isPovBindOf(i)) {
+				return (i.getPOV((this.getPortValue() - i.getButtonCount() - 1) / 4) / 90.0 + 1) == this.getPortValue()
+						- i.getButtonCount();
+			} else if (this.compatible(i)) {
+				return i.getRawButtonPressed(this.getPortValue());
+			}
+			return false;
+		}
+
+		default boolean getPressedValueOf(int p) {
+			if (this.isPovBindOf(p)) {
+				return (DriverStation.getStickPOV(p,
+						(this.getPortValue() - DriverStation.getStickButtonCount(p) - 1) / 4)
+						/ 90.0 + 1) == this.getPortValue() - DriverStation.getStickButtonCount(p);
+			} else if (this.compatible(p)) {
+				return DriverStation.getStickButtonPressed(p, this.getPortValue());
+			}
+			return false;
+		}
+
+		default boolean getReleasedValueOf(GenericHID i) {
+			if (this.isPovBindOf(i)) {
+				return (i.getPOV((this.getPortValue() - i.getButtonCount() - 1) / 4) / 90.0 + 1) == this.getPortValue()
+						- i.getButtonCount();
+			} else if (this.compatible(i)) {
+				return i.getRawButtonReleased(this.getPortValue());
+			}
+			return false;
+		}
+
+		default boolean getReleasedValueOf(int p) {
+			if (this.isPovBindOf(p)) {
+				return (DriverStation.getStickPOV(p,
+						(this.getPortValue() - DriverStation.getStickButtonCount(p) - 1) / 4)
+						/ 90.0 + 1) == this.getPortValue() - DriverStation.getStickButtonCount(p);
+			} else if (this.compatible(p)) {
+				return DriverStation.getStickButtonReleased(p, this.getPortValue());
+			}
+			return false;
+		}
+
+		default DigitalSupplier getSupplier(GenericHID i) {
+			if (this.isPovBindOf(i)) {
+				return () -> (i.getPOV((this.getPortValue() - i.getButtonCount() - 1) / 4) / 90.0 + 1) == this
+						.getPortValue()
+						- i.getButtonCount();
+			} else if (this.compatible(i)) {
+				return () -> i.getRawButton(this.getPortValue());
+			}
+			return () -> false;
+		}
+
+		default DigitalSupplier getSupplier(int p) {
+			if (this.isPovBindOf(p)) {
+				return () -> (DriverStation.getStickPOV(p,
+						(this.getPortValue() - DriverStation.getStickButtonCount(p) - 1) / 4) / 90.0
+						+ 1) == this.getPortValue()
+								- DriverStation.getStickButtonCount(p);
+			} else if (this.compatible(p)) {
+				return () -> DriverStation.getStickButton(p, this.getPortValue());
+			}
+			return () -> false;
+		}
+
+		default DigitalSupplier getPressedSupplier(GenericHID i) {
+			if (this.isPovBindOf(i)) {
+				return () -> (i.getPOV((this.getPortValue() - i.getButtonCount() - 1) / 4) / 90.0 + 1) == this
+						.getPortValue()
+						- i.getButtonCount();
+			} else if (this.compatible(i)) {
+				return () -> i.getRawButtonPressed(this.getPortValue());
+			}
+			return () -> false;
+		}
+
+		default DigitalSupplier getPressedSupplier(int p) {
+			if (this.isPovBindOf(p)) {
+				return () -> (DriverStation.getStickPOV(p,
+						(this.getPortValue() - DriverStation.getStickButtonCount(p) - 1) / 4) / 90.0
+						+ 1) == this.getPortValue()
+								- DriverStation.getStickButtonCount(p);
+			} else if (this.compatible(p)) {
+				return () -> DriverStation.getStickButtonPressed(p, this.getPortValue());
+			}
+			return () -> false;
+		}
+
+		default DigitalSupplier getReleasedSupplier(GenericHID i) {
+			if (this.isPovBindOf(i)) {
+				return () -> (i.getPOV((this.getPortValue() - i.getButtonCount() - 1) / 4) / 90.0 + 1) == this
+						.getPortValue()
+						- i.getButtonCount();
+			} else if (this.compatible(i)) {
+				return () -> i.getRawButtonReleased(this.getPortValue());
+			}
+			return () -> false;
+		}
+
+		/**
+		 * 
+		 * @param port The port to check
+		 * @return
+		 */
+		default DigitalSupplier getReleasedSupplier(int port) {
+			if (this.isPovBindOf(port)) {
+				return () -> (DriverStation.getStickPOV(port,
+						(this.getPortValue() - DriverStation.getStickButtonCount(port) - 1) / 4) / 90.0
+						+ 1) == this.getPortValue()
+								- DriverStation.getStickButtonCount(port);
+			} else if (this.compatible(port)) {
+				return () -> DriverStation.getStickButtonReleased(port, this.getPortValue());
+			}
+			return () -> false;
+		}
+	}
+
+	/**
+	 * InputMap defines all functions available to Input classes that contain an
+	 * AnalogMap and DigitalMap
+	 */
+	public static abstract class InputMap {
+		/**
+		 * Returns whether the given HID is compatible with the Analog and Digital enums
+		 * defined in the class.
+		 * 
+		 * @param i The HID to check
+		 * @return Whether the given HID is compatible
+		 */
+		public abstract boolean compatible(GenericHID i);
+
+		/**
+		 * Returns whether the given port is compatible with the Analog and Digital
+		 * enums
+		 * defined in the class.
+		 * 
+		 * @param port The port to check
+		 * @return Whether the given port is compatible
+		 */
+		public abstract boolean compatible(int port);
+
+		/**
+		 * A helper function that returns whether the given HID is compatible with the
+		 * Analog and Digital enums defined in the class, given the specific AnalogMap
+		 * and DigitalMap enums.
+		 * 
+		 * @param i The HID to check
+		 * @param a The AnalogMap enum to check
+		 * @param d The DigitalMap enum to check
+		 * @return Whether the given HID is compatible with the given AnalogMap and
+		 *         DigitalMap enums
+		 */
+		protected boolean compat(GenericHID i, AnalogMap a, DigitalMap d) {
+			return a.compatible(i) && d.compatible(i);
+		}
+
+		/**
+		 * A helper function that returns whether the given port is compatible with the
+		 * Analog and Digital enums defined in the class, given the specific AnalogMap
+		 * and DigitalMap enums.
+		 * 
+		 * @param port The port to check
+		 * @param a    The AnalogMap enum to check
+		 * @param d    The DigitalMap enum to check
+		 * @return Whether the given port is compatible with the given AnalogMap and
+		 *         DigitalMap enums
+		 */
+		protected boolean compat(int port, AnalogMap a, DigitalMap d) {
+			return a.compatible(port) && d.compatible(port);
+		}
+	}
+
+	/**
+	 * All button and axis indices for an Xbox controller
+	 */
+	public static class Xbox extends InputMap {
+		public static enum Analog implements AnalogMap {
+			LX(0), RX(4), LY(1), RY(5), LT(2), RT(3),
+			TOTAL(6);
+
+			public final int value;
+
+			private Analog(int value) {
+				this.value = value;
+			}
+
+			/**
+			 * @return The port number of the selected button or axis
+			 */
+			public int getPortValue() {
+				return this.value;
+			}
+
+			/**
+			 * @return The total number of port options
+			 */
+			public int getTotal() {
+				return TOTAL.value;
+			}
+		}
+
+		public static enum Digital implements DigitalMap {
+			LB(5), RB(6), LS(9), RS(10),
+			A(1), B(2), X(3), Y(4),
+			BACK(7), START(8),
+			DT(11), DR(12), DB(13), DL(14), // D-Pad buttons (only valid with PovButton objects)
+			TOTAL(14);
+
+			public final int value;
+
+			private Digital(int value) {
+				this.value = value;
+			}
+
+			/**
+			 * @return The port number of the selected button or axis
+			 */
+			public int getPortValue() {
+				return this.value;
+			}
+
+			/**
+			 * @return The total number of port options
+			 */
+			public int getTotal() {
+				return TOTAL.value;
+			}
+		}
+
+		private Xbox() {
+		}
+
+		public static final Xbox Map = new Xbox();
+
+		public boolean compatible(GenericHID i) {
+			return super.compat(i, Analog.TOTAL, Digital.TOTAL);
+		}
+
+		public boolean compatible(int p) {
+			return super.compat(p, Analog.TOTAL, Digital.TOTAL);
+		}
+	}
+
+	/**
+	 * All button and axis indices for a Playstation controller
+	 */
+	public static class PlayStation extends InputMap {
+		public static enum Analog implements AnalogMap {
+			LX(0), LY(1), RX(2), RY(5), LT(3), RT(4),
+			TOTAL(6);
+
+			public final int value;
+
+			private Analog(int value) {
+				this.value = value;
+			}
+
+			/**
+			 * @return The port number of the selected button or axis
+			 */
+			public int getPortValue() {
+				return this.value;
+			}
+
+			/**
+			 * @return The total number of port options
+			 */
+			public int getTotal() {
+				return TOTAL.value;
+			}
+		}
+
+		public static enum Digital implements DigitalMap {
+			SQR(1), X(2), O(3), TRI(4), // square, cross, circle, triangle
+			LB(5), RB(6), L2(7), R2(8), // right-bumper, left-bumper, left-trigger, right-trigger (button mode)
+			SHARE(9), OPT(10), PS(13), // share, options, ps button
+			TOUCH(14), LS(11), RS(12), // touchpad, left-stick, right-stick
+			TOTAL(14);
+
+			public final int value;
+
+			private Digital(int value) {
+				this.value = value;
+			}
+
+			/**
+			 * @return The port number of the selected button or axis
+			 */
+			public int getPortValue() {
+				return this.value;
+			}
+
+			/**
+			 * @return The total number of port options
+			 */
+			public int getTotal() {
+				return TOTAL.value;
+			}
+		}
+
+		private PlayStation() {
+		}
+
+		public static final PlayStation Map = new PlayStation();
+
+		public boolean compatible(GenericHID i) {
+			return super.compat(i, Analog.TOTAL, Digital.TOTAL);
+		}
+
+		public boolean compatible(int p) {
+			return super.compat(p, Analog.TOTAL, Digital.TOTAL);
+		}
+	}
+
+	/**
+	 * All button and axis indices for an Attack3 joystick
+	 */
+	public static class Attack3 extends InputMap {
+		public static enum Analog implements AnalogMap {
+			X(0), Y(1), S(2), // ~ X-Axis, Y-Axis, Slider thing on the bottom
+			TOTAL(3);
+
+			public final int value;
+
+			private Analog(int value) {
+				this.value = value;
+			}
+
+			/**
+			 * @return The port number of the selected button or axis
+			 */
+			public int getPortValue() {
+				return this.value;
+			}
+
+			/**
+			 * @return The total number of port options
+			 */
+			public int getTotal() {
+				return TOTAL.value;
+			}
+		}
+
+		public static enum Digital implements DigitalMap {
+			TRI(1), TB(2), TT(3), TL(4), TR(5), // ~ trigger, top-bottom, top-top, top-left, top-right
+			B1(6), B2(7), B3(8), B4(9), B5(10), B6(11), // ~ buttons on the base of the joystick (labeled)
+			TOTAL(11);
+
+			public final int value;
+
+			private Digital(int value) {
+				this.value = value;
+			}
+
+			/**
+			 * @return The port number of the selected button or axis
+			 */
+			public int getPortValue() {
+				return this.value;
+			}
+
+			/**
+			 * @return The total number of port options
+			 */
+			public int getTotal() {
+				return TOTAL.value;
+			}
+		}
+
+		private Attack3() {
+		}
+
+		public static final Attack3 Map = new Attack3();
+
+		public boolean compatible(GenericHID i) {
+			return super.compat(i, Analog.TOTAL, Digital.TOTAL);
+		}
+
+		public boolean compatible(int p) {
+			return super.compat(p, Analog.TOTAL, Digital.TOTAL);
+		}
+	}
+
+	/**
+	 * All button and axis indices for an Extreme3D joystick
+	 */
+	public static class Extreme3d extends InputMap {
+		public static enum Analog implements AnalogMap {
+			X(0), Y(1), Z(2), S(3), // x-axis, y-axis, swivel-axis, slider-axis
+			TOTAL(4);
+
+			public final int value;
+
+			private Analog(int value) {
+				this.value = value;
+			}
+
+			/**
+			 * @return The port number of the selected button or axis
+			 */
+			public int getPortValue() {
+				return this.value;
+			}
+
+			/**
+			 * @return The total number of port options
+			 */
+			public int getTotal() {
+				return TOTAL.value;
+			}
+		}
+
+		public static enum Digital implements DigitalMap {
+			TRI(1), SIDE(2), TLB(3), TRB(4), TLT(5), TRT(6), // trigger, side, top-left-bottom, top-right-bottom,
+																// top-left-top, top-right-top
+			B7(7), B8(8), B9(9), B10(10), B11(11), B12(12), // as printed on the actual joystick
+			TOTAL(12);
+
+			public final int value;
+
+			private Digital(int value) {
+				this.value = value;
+			}
+
+			/**
+			 * @return The port number of the selected button or axis
+			 */
+			public int getPortValue() {
+				return this.value;
+			}
+
+			/**
+			 * @return The total number of port options
+			 */
+			public int getTotal() {
+				return TOTAL.value;
+			}
+		}
+
+		private Extreme3d() {
+		}
+
+		public static final Extreme3d Map = new Extreme3d();
+
+		public boolean compatible(GenericHID i) {
+			return super.compat(i, Analog.TOTAL, Digital.TOTAL);
+		}
+
+		public boolean compatible(int p) {
+			return super.compat(p, Analog.TOTAL, Digital.TOTAL);
+		}
+	}
+
+	/**
+	 * All button and axis indices for the Button Box (as of 2024)
+	 */
+	public static class ButtonBox extends InputMap {
+		public static enum Digital implements DigitalMap {
+			B1(1), B2(2), B3(3), B4(4), B5(5), B6(6),
+			S1(7), S2(8),
+			TOTAL(16); // whatever interface board the Button Box is using apparently has 12 buttons
+						// and 1
+						// POV
+
+			public final int value;
+
+			private Digital(int v) {
+				this.value = v;
+			}
+
+			/**
+			 * @return The port number of the selected button or axis
+			 */
+			public int getPortValue() {
+				return this.value;
+			}
+
+			/**
+			 * @return The total number of port options
+			 */
+			public int getTotal() {
+				return TOTAL.value;
+			}
+		}
+
+		private ButtonBox() {
+		}
+
+		public static final ButtonBox Map = new ButtonBox();
+		public static final int AXIS_COUNT = 5; // see the last comment --> the Button Box apparently has 5 axis
+
+		public boolean compatible(GenericHID i) {
+			return Digital.TOTAL.compatible(i) && i.getAxisCount() == AXIS_COUNT;
+		}
+
+		public boolean compatible(int p) {
+			return Digital.TOTAL.compatible(p) && DriverStation.getStickAxisCount(p) == AXIS_COUNT;
+		}
+	}
+
+}

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -29,6 +29,7 @@ import frc.robot.Constants;
 import frc.robot.RobotContainer;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.OIConstants;
+import frc.robot.controls.Controls;
 import frc.utils.SwerveUtils;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -157,6 +158,8 @@ public class DriveSubsystem extends SubsystemBase {
     SmartDashboard.putNumber("Front Right Velocity", m_frontRight.getState().speedMetersPerSecond);
     SmartDashboard.putNumber("Rear Left Velocity", m_rearLeft.getState().speedMetersPerSecond);
     SmartDashboard.putNumber("Rear Right Velocity", m_rearRight.getState().speedMetersPerSecond);
+    RobotContainer.loopScheme();
+    Controls.pollCommands();
   }
 
   /**


### PR DESCRIPTION
I would highly recommend pushing this before competition to minimize control issues.
Fixes:
- Double binding of triggers if new robot code is pushed without restarting the rio
- Incompatibilities between plugged in controls
Adds:
- Allows for debindable triggers
- Ease of use for testing with other control combinations
- Applies triggers based on device type instead of port (prevents issues caused by having devices in the wrong port)