### PR TITLE
Fix Compile Errors

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -42,7 +42,7 @@ public final class Constants {
     public static final int flingerCanID_1 = 11;
     public static final int flingerCanID_2 = 12;
     // A small value to detect if the intake is not moving
-    public static final double INTAKE_RPM_DEADZONE = IntakeConstants.INTAKE_RPM_DEADZONE;
+    public static final double FLINGER_RPM_DEADZONE = IntakeConstants.INTAKE_RPM_DEADZONE;
   }
 
   public static final class IntakeConstants {

--- a/vendordeps/PathplannerLib.json
+++ b/vendordeps/PathplannerLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PathplannerLib.json",
     "name": "PathplannerLib",
-    "version": "2024.1.3",
+    "version": "2024.2.8",
     "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
     "frcYear": "2024",
     "mavenUrls": [
@@ -12,7 +12,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-java",
-            "version": "2024.1.3"
+            "version": "2024.2.8"
         }
     ],
     "jniDependencies": [],
@@ -20,7 +20,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-cpp",
-            "version": "2024.1.3",
+            "version": "2024.2.8",
             "libName": "PathplannerLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
FLINGER constant was misnamed.

Pathplanner vendor dependency needed to be updated to compile.